### PR TITLE
fix: perceptual logic of icons

### DIFF
--- a/client/src/components/Actions/TableActions.tsx
+++ b/client/src/components/Actions/TableActions.tsx
@@ -57,9 +57,9 @@ export const TableActions = (props: Props): JSX.Element => {
           tabIndex={0}
         >
           {entity.isPinned ? (
-            <Icon icon="mdiPinOff" color="var(--color-accent)" />
-          ) : (
             <Icon icon="mdiPin" />
+          ) : (
+            <Icon icon="mdiPinOff" color="var(--color-accent)" />
           )}
         </div>
       )}
@@ -71,9 +71,9 @@ export const TableActions = (props: Props): JSX.Element => {
         tabIndex={0}
       >
         {entity.isPublic ? (
-          <Icon icon="mdiEyeOff" color="var(--color-accent)" />
-        ) : (
           <Icon icon="mdiEye" />
+        ) : (
+          <Icon icon="mdiEyeOff" color="var(--color-accent)" />
         )}
       </div>
     </td>


### PR DESCRIPTION
Previously:
pinned = crossed out pin
public = crossed out eye
unpinned = pin
hidden = eye

Now:
pinned = pin
public = eye
unpinned = crossed out pin
hidden = crossed out eye